### PR TITLE
Add Trie implementation for autocomplete functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Dart specific - for all date-based project directories
+*/.dart_tool/
+*/build/
+*/pubspec.lock
+
+# IDE specific
+.idea/
+.vscode/
+*.iml
+
+# Miscellaneous
+.DS_Store
+*.log
+
+# Keep all pubspec.yaml files
+!*/pubspec.yaml
+
+# Keep all lib and test directories
+!*/lib/
+!*/test/

--- a/20241028/lib/naive.dart
+++ b/20241028/lib/naive.dart
@@ -1,0 +1,54 @@
+/// 20241028
+///
+///
+void main() {
+  final testDictionary = [
+    // Words starting with 'de'
+    'deer', 'deal', 'deep', 'defeat', 'december',
+
+    // Words starting with 'do'
+    'dog', 'door', 'document', 'dolphin', 'domain',
+
+    // Words starting with 'da'
+    'data', 'dark', 'dance', 'dash', 'date',
+
+    // Other 'd' words
+    'drum', 'drift', 'dream', 'draft', 'drink',
+
+    // Non 'd' words for variety
+    'cat', 'car', 'care', 'careful', 'career',
+    'bear', 'beach', 'begin', 'behind', 'better',
+    'apple', 'apply', 'approve', 'april', 'area'
+  ];
+
+  // Sort the dictionary for better readability
+  testDictionary.sort();
+
+  // Print dictionary statistics
+  printDictionaryStats(testDictionary);
+}
+
+void printDictionaryStats(List<String> dictionary) {
+  // Using a Map to store words by prefix
+  final prefixes = <String, List<String>>{};
+
+  for (final word in dictionary) {
+    if (word.length >= 2) {
+      final prefix = word.substring(0, 2);
+      prefixes.putIfAbsent(prefix, () => []);
+      prefixes[prefix]!.add(word);
+    }
+  }
+
+  // Print statistics
+  print('Total words: ${dictionary.length}\n');
+  print('Words by prefix:');
+
+  // Sort prefixes for consistent output
+  final sortedPrefixes = prefixes.keys.toList()..sort();
+
+  for (final prefix in sortedPrefixes) {
+    final words = prefixes[prefix]!;
+    print('$prefix-: ${words.length} words - $words');
+  }
+}

--- a/20241028/lib/src/trie/trie.dart
+++ b/20241028/lib/src/trie/trie.dart
@@ -31,7 +31,9 @@ class Trie {
   /// Returns:
   ///   A list of all words that start with the given prefix.
   ///   An empty list if no words are found with the given prefix.
-  List<String> findWordsWithPrefix(String prefix) {
+  List<String> findWordsWithPrefix(String prefix,
+      {bool includeEmptyPrefix = false}) {
+    if (prefix.isEmpty && !includeEmptyPrefix) return <String>[];
     var current = _root;
     var results = <String>[];
 

--- a/20241028/lib/src/trie/trie.dart
+++ b/20241028/lib/src/trie/trie.dart
@@ -1,0 +1,109 @@
+import 'package:leetcode20241028/src/trie/trie_node.dart';
+
+/// A Trie (prefix tree) data structure for efficient string prefix searches
+///
+/// This implementation provides functionality for:
+/// - Inserting words into the trie
+/// - Searching for words with a given prefix
+/// - Checking if a complete word exists in the trie
+class Trie {
+  final TrieNode _root;
+
+  /// Creates a new empty Trie with a root node.
+  Trie() : _root = TrieNode();
+
+  /// Inserts a word into the trie.
+  ///
+  /// Each character of the word is added as a node in the tree if it doesn't
+  /// already exists. The last node is marked as the end of a word.
+  void insert(String word) {
+    var current = _root;
+
+    for (var char in word.split('')) {
+      current = current.addChild(char);
+    }
+
+    current.isEndOfWord = true;
+  }
+
+  /// Searches for all words in the trie that start with the given prefix
+  ///
+  /// Returns:
+  ///   A list of all words that start with the given prefix.
+  ///   An empty list if no words are found with the given prefix.
+  List<String> findWordsWithPrefix(String prefix) {
+    var current = _root;
+    var results = <String>[];
+
+    /// Navigate through the prefix word
+    for (var char in prefix.split('')) {
+      var child = current.getChild(char);
+      if (child == null) {
+        return results; // child node does not exist for [char]
+      }
+      current = child; // traverse one letter down
+    }
+
+    // flatten the current subtree to collect all words from here down
+    _collectWords(current, prefix, results);
+    return results;
+  }
+
+  /// Helper method to flatten the current subtree and collect all
+  /// well-formed words henceforth.
+  ///
+  /// Parameters:
+  ///   - currentNode: the root of the current subtree
+  ///   - currentString: the current state of the prefix string
+  ///   - results: the collection of words to add to
+  void _collectWords(
+    TrieNode currentNode,
+    String currentString,
+    List<String> results,
+  ) {
+    if (currentNode.isEndOfWord) {
+      results.add(currentString);
+    }
+
+    /// recursively call child processes
+    for (var entry in currentNode.children.entries) {
+      _collectWords(entry.value, currentString + entry.key, results);
+    }
+  }
+
+  /// Checks for membership of a complete word.
+  /// Only returns true for complete words, not existing prefixes.
+  ///
+  /// Returns:
+  ///   true if the word exists in the trie, false otherwise.
+  bool contains(String word) {
+    var current = _root;
+
+    for (var char in word.split('')) {
+      var child = current.getChild(char);
+      if (child == null) {
+        return false;
+      }
+      current = child; // traverse further
+    }
+    // done with traversal, the prefix is in the trie
+    // needs additional check for completeness as a word
+    return current.isEndOfWord;
+  }
+
+  /// Returns the number of compelte words stored in the trie.
+  ///
+  /// This is a helper method primarily useful for testing/debugging.
+  int get wordCount {
+    var count = 0;
+
+    /// recursive routine to modify the "global" count
+    void countWords(TrieNode node) {
+      if (node.isEndOfWord) count++;
+      node.children.values.forEach(countWords);
+    }
+
+    countWords(_root);
+    return count;
+  }
+}

--- a/20241028/lib/src/trie/trie_node.dart
+++ b/20241028/lib/src/trie/trie_node.dart
@@ -1,0 +1,32 @@
+/// A node in a trie data structure.
+///
+/// Each node represents a character in the trie and maintains:
+/// - A map of child nodes for subsequent characters
+/// - A flag indicating if this node represents the end of a word
+///   (so that we can distinguish `run` and `running` from inbetween
+///   strings)
+class TrieNode {
+  /// Maps characters to their corresponding child nodes
+  final Map<String, TrieNode> children = {};
+
+  /// Whether this nodes represents the end of a word
+  bool isEndOfWord = false;
+
+  /// Creates a new TrieNode instance
+  TrieNode();
+
+  /// Whether this node has a child represented by [char]
+  bool hasChild(String char) => children.containsKey(char);
+
+  /// Gets the child node represented by [char]
+  ///
+  /// Returns the child [TrieNode] if it exists, null otherwise
+  TrieNode? getChild(String char) => children[char];
+
+  /// Adds a child node with [char] as its representation if it doesn't exist
+  ///
+  /// Returns the existing or newly created child node
+  TrieNode addChild(String char) {
+    return children.putIfAbsent(char, () => TrieNode());
+  }
+}

--- a/20241028/pubspec.yaml
+++ b/20241028/pubspec.yaml
@@ -1,0 +1,9 @@
+name: leetcode20241028
+description: 
+version: 1.0.0
+environment:
+  sdk: '>=3.0.0 <=4.0.0'
+dependencies:
+  collection: ^1.16.0
+dev_dependencies:
+  test: ^1.25.8

--- a/20241028/test/naive_test.dart
+++ b/20241028/test/naive_test.dart
@@ -1,0 +1,3 @@
+import 'package:test/test.dart';
+import 'package:leetcode20241028/lib/naive.dart';
+

--- a/20241028/test/trie_node_test.dart
+++ b/20241028/test/trie_node_test.dart
@@ -1,0 +1,71 @@
+import 'package:test/test.dart';
+import 'package:leetcode20241028/src/trie/trie_node.dart';
+
+void main() {
+  group('TrieNode', () {
+    late TrieNode node;
+
+    setUp(() {
+      node = TrieNode(); // called every test
+    });
+
+    test('should initialize with empty children and !isEndOfWord', () {
+      expect(node.children, isEmpty);
+      expect(node.isEndOfWord, isFalse);
+    });
+
+    group('hasChild', () {
+      test('should return false for non-existent child', () {
+        expect(node.hasChild('a'), isFalse);
+      });
+      test('should return true for existing child', () {
+        node.addChild('a');
+        expect(node.hasChild('a'), isTrue);
+      });
+    });
+
+    group('getChild', () {
+      test('should return null for non-existent child', () {
+        expect(node.getChild('a'), isNull);
+      });
+      test('should return child node for existing child', () {
+        final child = node.addChild('a');
+        expect(node.getChild('a'), equals(child));
+      });
+    });
+
+    group('addChild', () {
+      test('should create new child node if none exists', () {
+        final child = node.addChild('a');
+        expect(child, isNotNull);
+        expect(node.children['a'], equals(child));
+      });
+
+      test('should return existing child if already exists', () {
+        final firstChild = node.addChild('a');
+        final secondChild = node.addChild('a');
+        expect(secondChild, equals(firstChild));
+        expect(node.children.length, equals(1));
+      });
+
+      test('should create distinct nodes for different characters', () {
+        final childA = node.addChild('a');
+        final childB = node.addChild('b');
+        expect(node.children.length, equals(2));
+        expect(childA, isNot(equals(childB)));
+      });
+    });
+
+    // integration
+    test('should support multiple levels of children', () {
+      final childA = node.addChild('a');
+      final childB = childA.addChild('b');
+      final childC = childB.addChild('c');
+
+      expect(node.hasChild('a'), isTrue);
+      expect(childA.hasChild('b'), isTrue);
+      expect(childB.hasChild('c'), isTrue);
+      expect(childC.children, isEmpty);
+    });
+  });
+}

--- a/20241028/test/trie_test.dart
+++ b/20241028/test/trie_test.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:test/test.dart';
 import 'package:leetcode20241028/src/trie/trie.dart';
 
@@ -72,7 +70,7 @@ void main() {
     });
 
     group('findWordsWithPrefix', () {
-      late final List<String> words;
+      late List<String> words;
       setUp(() {
         words = "test team tea testing teammate".split(' ');
         words.forEach(trie.insert);
@@ -88,15 +86,13 @@ void main() {
       test('find subset of words with longer prefix `tea`', () {
         final prefix = 'tea';
         final searchResults = trie.findWordsWithPrefix(prefix);
-        expect(searchResults.length, equals(words.length));
-        expect(searchResults, containsAll(words));
+        expect(searchResults.length, equals(3));
       });
 
       test('finds single word with exact match', () {
         final prefix = 'teammate';
         final searchResults = trie.findWordsWithPrefix(prefix);
-        expect(searchResults.length, equals(words.length));
-        expect(searchResults, containsAll(words));
+        expect(searchResults.length, equals(1));
         expect(trie.contains('teammate'), isTrue);
       });
 
@@ -112,7 +108,10 @@ void main() {
       });
 
       test('returns full list for empty prefix with flag', () {
-        final searchResults = trie.findWordsWithPrefix('');
+        final searchResults = trie.findWordsWithPrefix(
+          '',
+          includeEmptyPrefix: true,
+        );
         expect(searchResults.length, equals(words.length));
       });
     });

--- a/20241028/test/trie_test.dart
+++ b/20241028/test/trie_test.dart
@@ -1,0 +1,71 @@
+import 'package:test/test.dart';
+import 'package:leetcode20241028/src/trie/trie_node.dart';
+
+void main() {
+  group('TrieNode', () {
+    late TrieNode node;
+
+    setUp(() {
+      node = TrieNode(); // called every test
+    });
+
+    test('should initialize with empty children and !isEndOfWord', () {
+      expect(node.children, isEmpty);
+      expect(node.isEndOfWord, isFalse);
+    });
+
+    group('hasChild', () {
+      test('should return false for non-existent child', () {
+        expect(node.hasChild('a'), isFalse);
+      });
+      test('should return true for existing child', () {
+        node.addChild('a');
+        expect(node.hasChild('a'), isTrue);
+      });
+    });
+
+    group('getChild', () {
+      test('should return null for non-existent child', () {
+        expect(node.getChild('a'), isNull);
+      });
+      test('should return child node for existing child', () {
+        final child = node.addChild('a');
+        expect(node.getChild('a'), equals(child));
+      });
+    });
+
+    group('addChild', () {
+      test('should create new child node if none exists', () {
+        final child = node.addChild('a');
+        expect(child, isNotNull);
+        expect(node.children['a'], equals(child));
+      });
+
+      test('should return existing child if already exists', () {
+        final firstChild = node.addChild('a');
+        final secondChild = node.addChild('a');
+        expect(secondChild, equals(firstChild));
+        expect(node.children.length, equals(1));
+      });
+
+      test('should create distinct nodes for different characters', () {
+        final childA = node.addChild('a');
+        final childB = node.addChild('b');
+        expect(node.children.length, equals(2));
+        expect(childA, isNot(equals(childB)));
+      });
+    });
+
+    // integration
+    test('should support multiple levels of children', () {
+      final childA = node.addChild('a');
+      final childB = childA.addChild('b');
+      final childC = childB.addChild('c');
+
+      expect(node.hasChild('a'), isTrue);
+      expect(childA.hasChild('b'), isTrue);
+      expect(childB.hasChild('c'), isTrue);
+      expect(childC.children, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
# Trie-based Autocompletion Implementation

## Changes
- Implement Trie data structure for efficient prefix searching
- Add configurable prefix search behavior
- Add comprehensive test suite

## Implementation Details
- `TrieNode`: basic node structure with children map
- `Trie`: main class with
    - Word insertion
    - Prefix searching
    - Membership testing
    - Configurable empty prefix behavior

## Testing
- Full test coverage of core operations
- Edge cases (empty string, special character set, Unicode)