### PR TITLE
Add Validator Implementation for UTF-8 Encoding Rules

### DIFF
--- a/20241114/README.md
+++ b/20241114/README.md
@@ -68,7 +68,7 @@ UTF-8 is a variable-width character encoding that uses one to four bytes to repr
 4. Invalid continuation bytes
 
 ## Constraints
-- Input array length: 1 ≤ n ≤ 10^4
+- Input array length: 1 ≤ n ≤ 4 (only validate one character at a time)
 - Byte values: 0 ≤ value ≤ 255
 
 ## Performance Requirements

--- a/20241114/README.md
+++ b/20241114/README.md
@@ -1,0 +1,76 @@
+# UTF-8 Validator
+## Problem Statement
+Implement a function that validates whether a given sequence of bytes represents a valid UTF-8 encoding.
+
+## Background
+UTF-8 is a variable-width character encoding that uses one to four bytes to represent Unicode characters. Each multi-byte character follows a specific pattern where:
+- The first byte indicates the total number of bytes for the character
+- Any subsequent bytes follow a continuation pattern
+
+## Input
+- An array of integers where each integer represents a byte value (0-255)
+- Example: `[230, 130, 172]` represents the Euro sign (€)
+
+## Output
+- Boolean value
+  - `true` if the byte sequence is a valid UTF-8 encoding
+  - `false` if the byte sequence is invalid
+
+## Encoding Rules
+### Byte Patterns
+
+```
+ Bytes   |           Byte format
+-----------------------------------------------
+   1     | 0xxxxxxx                            # Single byte - ASCII
+   2     | 110xxxxx 10xxxxxx                   # Two bytes
+   3     | 1110xxxx 10xxxxxx 10xxxxxx          # Three bytes
+   4     | 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx # Four bytes
+```
+
+### Validation Rules
+1. **First Byte Pattern**
+   - For single-byte character: first bit must be 0
+   - For n-byte character: first byte starts with n ones followed by a zero
+
+2. **Continuation Byte Pattern**
+   - All continuation bytes must start with '10'
+   - Number of continuation bytes must match the pattern indicated by the first byte
+
+3. **General Rules**
+   - Each byte value must be between 0 and 255
+   - The sequence must contain complete characters (no partial characters)
+   - Maximum of 4 bytes per character
+
+## Example Cases
+1. Valid single byte:
+   ```
+   Input: [65]  # ASCII 'A'
+   Output: true
+   ```
+
+2. Valid multi-byte (Euro sign):
+   ```
+   Input: [230, 130, 172]  # '€'
+   Output: true
+   ```
+
+3. Invalid sequence:
+   ```
+   Input: [230, 256, 172]  # Invalid byte value
+   Output: false
+   ```
+
+## Edge Cases to Consider
+1. Empty input array
+2. Incomplete sequences
+3. Invalid byte values (> 255)
+4. Invalid continuation bytes
+
+## Constraints
+- Input array length: 1 ≤ n ≤ 10^4
+- Byte values: 0 ≤ value ≤ 255
+
+## Performance Requirements
+- Time Complexity: O(n) where n is the length of the input array
+- Space Complexity: O(1)

--- a/20241114/lib/utf8_validator.dart
+++ b/20241114/lib/utf8_validator.dart
@@ -4,6 +4,22 @@
 /// This validator takes in a representation of one UTF-8 encoded
 /// character and validates it against the encoding rules.
 class UTF8Validator {
+  // Byte pattern masks and values as static constants
+  static const _SINGLE_BYTE_MASK = 0x80; // 10000000
+  static const _TWO_BYTES_MASK = 0xE0; // 11100000
+  static const _THREE_BYTES_MASK = 0xF0; // 11110000
+  static const _FOUR_BYTES_MASK = 0xF8; // 11111000
+  static const _CONT_BYTE_MASK = 0xC0; // 11000000
+
+  static const _TWO_BYTES_PATTERN = 0xC0; // 11000000
+  static const _THREE_BYTES_PATTERN = 0xE0; // 111static const
+  static const _FOUR_BYTES_PATTERN = 0xF0; // 111static const
+  static const _CONT_BYTE_PATTERN = 0x80; // 10000000
+
+  static const _MAX_BYTES = 5;
+  static const _MIN_BYTE_VALUE = 0;
+  static const _MAX_BYTE_VALUE = 255;
+
   /// Creates a UTF8_Validator instance
   UTF8Validator();
 
@@ -38,17 +54,32 @@ class UTF8Validator {
   /// Output: False if list has too many byte values (max 4) or if
   ///         any integer value falls out of the value range for a byte
   bool _validateByteSequence(List<int> bytes) {
-    if (bytes.length > 4) return false;
-    if (!_isValidByteRange(bytes)) return false;
+    // Empty sequence is valid per UTF-8 specs
+    if (bytes.isEmpty) return true;
+
+    // Validates sequence length
+    if (bytes.length > _MAX_BYTES) return false;
+
+    // throws [RangeError] if any value is not in valid range
+    _validateByteRange(bytes);
+
     return _validateUTF8ByteList(bytes);
   }
 
-  /// Helper method to enforce byte value range constraint.
+  /// Validates that all byte values are within valid range [0-255].
   ///
-  /// Output: True if every integer in the list has value between
-  ///         0 and 255, false otherwise.
-  bool _isValidByteRange(List<int> bytes) {
-    return bytes.every((byte) => byte >= 0 && byte <= 255);
+  /// Throws [RangeError] for any invalid value.
+  void _validateByteRange(List<int> bytes) {
+    for (var i = 0; i < bytes.length; i++) {
+      if (bytes[i] < _MIN_BYTE_VALUE || bytes[i] > _MAX_BYTE_VALUE) {
+        throw RangeError.range(
+          bytes[i],
+          _MIN_BYTE_VALUE,
+          _MAX_BYTE_VALUE,
+          'byte value at index $i',
+        );
+      }
+    }
   }
 
   /// Validates an encoding of UTF8 standard with an integer-based

--- a/20241114/lib/utf8_validator.dart
+++ b/20241114/lib/utf8_validator.dart
@@ -1,8 +1,10 @@
-/// A validator for UTF-8 encoded characters with various forms
-/// of representation.
+/// A validator for UTF-8 encoded character sequences.
 ///
-/// This validator takes in a representation of one UTF-8 encoded
-/// character and validates it against the encoding rules.
+/// Validates whether a given encoded sequence follows UTF-8 encoding rules:
+/// - Single byte: 0xxxxxxx
+/// - Two bytes: 110xxxxx 10xxxxxx
+/// - Three bytes: 1110xxxx 10xxxxxx 10xxxxxx
+/// - Four bytes: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
 class UTF8Validator {
   // Byte pattern masks and values as static constants
   static const _SINGLE_BYTE_MASK = 0x80; // 10000000
@@ -20,17 +22,16 @@ class UTF8Validator {
   static const _MIN_BYTE_VALUE = 0;
   static const _MAX_BYTE_VALUE = 255;
 
-  /// Investigates unknown forms of representation for the UTF-8
-  /// encoded character and dispatches the processing responsibility.
+  /// Validates a UTF-8 encoded character sequence.
   ///
-  /// Currently supported forms:
-  /// - List of integer-based byte values
+  /// Currently supports:
+  /// - List<int> representing byte values
   ///
-  /// Parameter:
-  ///   encoding: An unknown representation form of one UTF-8 encoded character.
+  /// Throws:
+  /// - [ArgumentError] if the input format is not supported
+  /// - [RangeError] if any byte value is outside valid range [0-255]
   ///
-  /// Output: True if the representation constitutes a valid UTF-8
-  ///         encoded character, false otherwise.
+  /// Returns true if the sequence is a valid UTF-8 encoding, false otherwise
   bool validate(Object encoding) {
     return switch (encoding) {
       List<int> list => _validateByteSequence(list),
@@ -45,11 +46,9 @@ class UTF8Validator {
   // TODO: Implement string validation logic
   // }
 
-  /// Helper validation method for the List of Bytes representation
-  /// for a UTF-8 encoded character.
+  /// Validates a sequence of bytes against UTF-8 encoding rules.
   ///
-  /// Output: False if list has too many byte values (max 4) or if
-  ///         any integer value falls out of the value range for a byte
+  /// Throws [RangeError] for any invalid byte value
   bool _validateByteSequence(List<int> bytes) {
     // Empty sequence is valid per UTF-8 specs
     if (bytes.isEmpty) return true;
@@ -79,15 +78,6 @@ class UTF8Validator {
     }
   }
 
-  /// Validates an encoding of UTF8 standard with an integer-based
-  /// representation.
-  ///
-  /// Parameters:
-  ///   bytes: A list of integer values, each representing the byte value
-  ///          that together comprises the UTF8-encoded character.
-  ///
-  /// Output: True if the integer-based byte values constitute a valid
-  ///         UTF8 encoded character, false otherwise.
   /// Validates UTF-8 bit patterns for the byte sequence.
   bool _validateUTF8Patterns(List<int> bytes) {
     // helper functions to check byte pattern

--- a/20241114/lib/utf8_validator.dart
+++ b/20241114/lib/utf8_validator.dart
@@ -1,0 +1,108 @@
+/// A validator for UTF-8 encoded characters with various forms
+/// of representation.
+///
+/// This validator takes in a representation of one UTF-8 encoded
+/// character and validates it against the encoding rules.
+class UTF8_Validator {
+  /// Creates a UTF8_Validator instance
+  UTF8_Validator();
+
+  /// Investigates unknown forms of representation for the UTF-8
+  /// encoded character and dispatches the processing responsibility.
+  ///
+  /// Currently supported forms:
+  /// - List of integer-based byte values
+  ///
+  /// Parameter:
+  ///   encoding: An unknown representation form of one UTF-8 encoded character.
+  ///
+  /// Output: True if the representation constitutes a valid UTF-8
+  ///         encoded character, false otherwise.
+  bool validate(Object encoding) {
+    return switch (encoding) {
+      String s => _validateStringInput(s),
+      List<int> list => _validateByteList(list),
+      _ => throw ArgumentError(
+          "Unsupported encoding format: ${encoding.runtimeType}",
+        )
+    };
+  }
+
+  bool _validateStringInput(String rawInput) {
+    if (rawInput.isEmpty) return true;
+    return _validateUTF8String(rawInput);
+  }
+
+  /// Helper validation method for the List of Bytes representation
+  /// for a UTF-8 encoded character.
+  ///
+  /// Output: False if list has too many byte values (max 4) or if
+  ///         any integer value falls out of the value range for a byte
+  bool _validateByteList(List<int> bytes) {
+    if (bytes.length > 4) return false;
+    if (!_isValidByteRange(bytes)) return false;
+    return _validateUTF8ByteList(bytes);
+  }
+
+  /// Helper method to enforce byte value range constraint.
+  ///
+  /// Output: True if every integer in the list has value between
+  ///         0 and 255, false otherwise.
+  bool _isValidByteRange(List<int> bytes) {
+    return bytes.every((byte) => byte >= 0 && byte <= 255);
+  }
+
+  /// Helper method to validates an encoding of UTF8 standard with
+  /// a string representation.
+  ///
+  /// Parameters:
+  ///   s: A string representation of a UTF8-encoded character. [s] contains
+  ///      a string representation of the 32 bits that make up this character.
+  ///
+  /// Output: true if the string represents a set of 32 bits that comprise a
+  ///         valid UTF8 encoded character, false otherwise.
+  bool _validateUTF8String(String s) {
+    // not yet supported
+    return false;
+  }
+
+  /// Validates an encoding of UTF8 standard with an integer-based
+  /// representation.
+  ///
+  /// Parameters:
+  ///   bytes: A list of integer values, each representing the byte value
+  ///          that together comprises the UTF8-encoded character.
+  ///
+  /// Output: True if the integer-based byte values constitute a valid
+  ///         UTF8 encoded character, false otherwise.
+  bool _validateUTF8ByteList(List<int> bytes) {
+    final maskTwoBytes = 0xE0; // 11100000
+    final patternTwoBytes = 0xC0; // 11000000
+
+    final maskThreeBytes = 0xF0; // 11110000
+    final patternThreeBytes = 0xE0; // 11100000
+
+    final maskFourBytes = 0xF8; // 11111000
+    final patternFourBytes = 0xF0; // 11110000
+
+    final maskContinuation = 0xC0; // 11000000
+    final patternContinuation = 0x80; // 10000000
+
+    // helper functions to apply masks
+    bool hasValidPrefix(int byte, int mask, int pattern) =>
+        (byte & mask) == pattern;
+    bool isValidContinuation(int byte) =>
+        hasValidPrefix(byte, maskContinuation, patternContinuation);
+
+    return switch (bytes.length) {
+      1 => bytes[0] < (1 << 7),
+      2 => hasValidPrefix(bytes[0], maskTwoBytes, patternTwoBytes) &&
+          isValidContinuation(bytes[1]),
+      3 => hasValidPrefix(bytes[0], maskThreeBytes, patternThreeBytes) &&
+          bytes.sublist(1).every(isValidContinuation),
+      4 => hasValidPrefix(bytes[0], maskFourBytes, patternFourBytes) &&
+          bytes.sublist(1).every(isValidContinuation),
+      _ => false
+    };
+  }
+}

--- a/20241114/lib/utf8_validator.dart
+++ b/20241114/lib/utf8_validator.dart
@@ -3,9 +3,9 @@
 ///
 /// This validator takes in a representation of one UTF-8 encoded
 /// character and validates it against the encoding rules.
-class UTF8_Validator {
+class UTF8Validator {
   /// Creates a UTF8_Validator instance
-  UTF8_Validator();
+  UTF8Validator();
 
   /// Investigates unknown forms of representation for the UTF-8
   /// encoded character and dispatches the processing responsibility.
@@ -20,25 +20,24 @@ class UTF8_Validator {
   ///         encoded character, false otherwise.
   bool validate(Object encoding) {
     return switch (encoding) {
-      String s => _validateStringInput(s),
-      List<int> list => _validateByteList(list),
+      List<int> list => _validateByteSequence(list),
+      String => throw ArgumentError("String validation not yet supported"),
       _ => throw ArgumentError(
           "Unsupported encoding format: ${encoding.runtimeType}",
         )
     };
   }
 
-  bool _validateStringInput(String rawInput) {
-    if (rawInput.isEmpty) return true;
-    return _validateUTF8String(rawInput);
-  }
+  // bool _validateStringInput(String rawInput) {
+  // TODO: Implement string validation logic
+  // }
 
   /// Helper validation method for the List of Bytes representation
   /// for a UTF-8 encoded character.
   ///
   /// Output: False if list has too many byte values (max 4) or if
   ///         any integer value falls out of the value range for a byte
-  bool _validateByteList(List<int> bytes) {
+  bool _validateByteSequence(List<int> bytes) {
     if (bytes.length > 4) return false;
     if (!_isValidByteRange(bytes)) return false;
     return _validateUTF8ByteList(bytes);
@@ -50,20 +49,6 @@ class UTF8_Validator {
   ///         0 and 255, false otherwise.
   bool _isValidByteRange(List<int> bytes) {
     return bytes.every((byte) => byte >= 0 && byte <= 255);
-  }
-
-  /// Helper method to validates an encoding of UTF8 standard with
-  /// a string representation.
-  ///
-  /// Parameters:
-  ///   s: A string representation of a UTF8-encoded character. [s] contains
-  ///      a string representation of the 32 bits that make up this character.
-  ///
-  /// Output: true if the string represents a set of 32 bits that comprise a
-  ///         valid UTF8 encoded character, false otherwise.
-  bool _validateUTF8String(String s) {
-    // not yet supported
-    return false;
   }
 
   /// Validates an encoding of UTF8 standard with an integer-based

--- a/20241114/lib/utf8_validator.dart
+++ b/20241114/lib/utf8_validator.dart
@@ -18,7 +18,7 @@ class UTF8Validator {
   static const _FOUR_BYTES_PATTERN = 0xF0; // 111static const
   static const _CONT_BYTE_PATTERN = 0x80; // 10000000
 
-  static const _MAX_BYTES = 5;
+  static const _MAX_BYTES = 4;
   static const _MIN_BYTE_VALUE = 0;
   static const _MAX_BYTE_VALUE = 255;
 

--- a/20241114/pubspec.yaml
+++ b/20241114/pubspec.yaml
@@ -1,0 +1,9 @@
+name: leetcode20241114
+description: 
+version: 1.0.0
+environment:
+  sdk: '>=3.0.0 <=4.0.0'
+dependencies:
+  collection: ^1.16.0
+dev_dependencies:
+  test: ^1.25.8

--- a/20241114/test/utf8_validator_test.dart
+++ b/20241114/test/utf8_validator_test.dart
@@ -10,43 +10,70 @@ void main() {
     });
 
     group('Input validation', () {
-      test('throws ArgumentError for unsupported types', () {});
+      test('throws ArgumentError for unsupported types', () {
+        expect(() => validator.validate(42), throwsArgumentError);
+      });
 
-      test('throws ArgumentError for string input', () {});
+      test('throws ArgumentError for string input', () {
+        expect(() => validator.validate("t"), throwsArgumentError);
+      });
 
-      test('throws RangeError for byte values out of valid range', () {});
+      test('throws RangeError for byte values out of valid range', () {
+        expect(() => validator.validate([-1]), throwsRangeError);
+        expect(() => validator.validate([256]), throwsRangeError);
+      });
     });
 
     group('Empty Sequence validation', () {
-      test('validates empty byte sequence as true', () {});
+      test('validates empty byte sequence as true', () {
+        expect(validator.validate([]), isTrue);
+      });
     });
 
     group('single byte validation', () {
-      test('validates ASCII characters (0-127)', () {});
+      test('validates ASCII characters (0-127)', () {
+        expect(validator.validate([64]), isTrue);
+        expect(validator.validate([127]), isTrue);
+      });
 
-      test('invalidates bytes with MSB set', () {});
+      test('invalidates bytes with MSB set', () {
+        expect(validator.validate([128]), isFalse);
+        expect(validator.validate([255]), isFalse);
+      });
     });
 
     group('two byte sequence validation', () {
       test('validates valid two byte sequences', () {
         // Example: Latin small letter a with acute
+        expect(validator.validate([0xC3, 0xA1]), isTrue);
       });
-      test('invalidates sequences with wrong continuation byte', () {});
+      test('invalidates sequences with wrong continuation byte', () {
+        expect(validator.validate([0xC3, 0xC1]), isFalse);
+      });
     });
 
     group('three byte sequence validation', () {
       test('validates valid three byte sequences', () {
         // Example: Euro sign
+        expect(validator.validate([0xE2, 0x82, 0xAC]), isTrue);
       });
-      test('invalidates sequences with wrong continuation bytes', () {});
+      test('invalidates sequences with wrong continuation bytes', () {
+        expect(validator.validate([0xE2, 0xC2, 0xAC]), isFalse);
+        expect(validator.validate([0xE2, 0x82, 0xC0]), isFalse);
+      });
     });
 
     group('four byte sequence validation', () {
       test('validates valid four byte sequences', () {
-        // Example: Summation symbol / Greek capital Sigma
+        // Example: Emoji person bowing deeply
+        expect(validator.validate([0xF0, 0x9F, 0x99, 0x87]), isTrue);
       });
 
-      test('invalidates sequences with wrong continuation bytes', () {});
+      test('invalidates sequences with wrong continuation bytes', () {
+        expect(validator.validate([0xF0, 0xC0, 0x99, 0x87]), isFalse);
+        expect(validator.validate([0xF0, 0x9F, 0xC0, 0x87]), isFalse);
+        expect(validator.validate([0xF0, 0x9F, 0x99, 0xC0]), isFalse);
+      });
     });
 
     group('sequence length validation', () {

--- a/20241114/test/utf8_validator_test.dart
+++ b/20241114/test/utf8_validator_test.dart
@@ -2,11 +2,11 @@ import 'package:test/test.dart';
 import 'package:leetcode20241114/utf8_validator.dart';
 
 void main() {
-  group('UTF8_Validator', () {
-    late UTF8_Validator utf8Validator;
+  group('UTF8Validator', () {
+    late UTF8Validator utf8Validator;
 
     setUp(() {
-      utf8Validator = UTF8_Validator();
+      utf8Validator = UTF8Validator();
     });
 
     // UTF8_Validator does not have any data to initialize

--- a/20241114/test/utf8_validator_test.dart
+++ b/20241114/test/utf8_validator_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     group('Empty Sequence validation', () {
       test('validates empty byte sequence as true', () {
-        expect(validator.validate([]), isTrue);
+        expect(validator.validate(<int>[]), isTrue);
       });
     });
 

--- a/20241114/test/utf8_validator_test.dart
+++ b/20241114/test/utf8_validator_test.dart
@@ -3,62 +3,55 @@ import 'package:leetcode20241114/utf8_validator.dart';
 
 void main() {
   group('UTF8Validator', () {
-    late UTF8Validator utf8Validator;
+    late UTF8Validator validator;
 
     setUp(() {
-      utf8Validator = UTF8Validator();
+      validator = UTF8Validator();
     });
 
-    // UTF8_Validator does not have any data to initialize
-    // skipping test
+    group('Input validation', () {
+      test('throws ArgumentError for unsupported types', () {});
 
-    group('validate', () {
-      test('string validation not supported, should return false', () {
-        final utf8BitString = '11100010 10000010 10101100';
-        final isValid = utf8Validator.validate(utf8BitString);
-        expect(isValid, isFalse);
+      test('throws ArgumentError for string input', () {});
+
+      test('throws RangeError for byte values out of valid range', () {});
+    });
+
+    group('Empty Sequence validation', () {
+      test('validates empty byte sequence as true', () {});
+    });
+
+    group('single byte validation', () {
+      test('validates ASCII characters (0-127)', () {});
+
+      test('invalidates bytes with MSB set', () {});
+    });
+
+    group('two byte sequence validation', () {
+      test('validates valid two byte sequences', () {
+        // Example: Latin small letter a with acute
+      });
+      test('invalidates sequences with wrong continuation byte', () {});
+    });
+
+    group('three byte sequence validation', () {
+      test('validates valid three byte sequences', () {
+        // Example: Euro sign
+      });
+      test('invalidates sequences with wrong continuation bytes', () {});
+    });
+
+    group('four byte sequence validation', () {
+      test('validates valid four byte sequences', () {
+        // Example: Summation symbol / Greek capital Sigma
       });
 
-      group('byte sequence validation', () {
-        test('valid empty input', () {
-          final bytes = <int>[];
-          final isValid = utf8Validator.validate(bytes);
-          expect(isValid, isTrue);
-        });
-        test('valid single byte', () {
-          final bytes = [65];
-          final isValid = utf8Validator.validate(bytes);
-          expect(isValid, isTrue);
-        });
-        test('valid multi-byte', () {
-          final bytes = [230, 130, 172]; // '€'
-          final isValid = utf8Validator.validate(bytes);
-          expect(isValid, isTrue);
-        });
+      test('invalidates sequences with wrong continuation bytes', () {});
+    });
 
-        test('invalid byte sequence: invalid byte value range', () {
-          final bytes = [230, 256, 172];
-          final isValid = utf8Validator.validate(bytes);
-          expect(isValid, isFalse);
-        });
-
-        test('invalid byte sequence: more than 4 bytes', () {
-          final bytes = [230, 130, 172, 143, 143];
-          final isValid = utf8Validator.validate(bytes);
-          expect(isValid, isFalse);
-        });
-
-        test('invalid byte sequence: bad leading byte', () {
-          final bytes = [170, 130, 172];
-          final isValid = utf8Validator.validate(bytes);
-          expect(isValid, isFalse);
-        });
-
-        test('invalid byte sequence: bad continuation byte(s)', () {
-          final bytes = [230, 202, 138];
-          final isValid = utf8Validator.validate(bytes);
-          expect(isValid, isFalse);
-        });
+    group('sequence length validation', () {
+      test('invalidates sequences longer than 4 bytes', () {
+        expect(validator.validate([1, 1, 1, 1, 1]), isFalse);
       });
     });
   });

--- a/20241114/test/utf8_validator_test.dart
+++ b/20241114/test/utf8_validator_test.dart
@@ -1,0 +1,65 @@
+import 'package:test/test.dart';
+import 'package:leetcode20241114/utf8_validator.dart';
+
+void main() {
+  group('UTF8_Validator', () {
+    late UTF8_Validator utf8Validator;
+
+    setUp(() {
+      utf8Validator = UTF8_Validator();
+    });
+
+    // UTF8_Validator does not have any data to initialize
+    // skipping test
+
+    group('validate', () {
+      test('string validation not supported, should return false', () {
+        final utf8BitString = '11100010 10000010 10101100';
+        final isValid = utf8Validator.validate(utf8BitString);
+        expect(isValid, isFalse);
+      });
+
+      group('byte sequence validation', () {
+        test('valid empty input', () {
+          final bytes = <int>[];
+          final isValid = utf8Validator.validate(bytes);
+          expect(isValid, isTrue);
+        });
+        test('valid single byte', () {
+          final bytes = [65];
+          final isValid = utf8Validator.validate(bytes);
+          expect(isValid, isTrue);
+        });
+        test('valid multi-byte', () {
+          final bytes = [230, 130, 172]; // '€'
+          final isValid = utf8Validator.validate(bytes);
+          expect(isValid, isTrue);
+        });
+
+        test('invalid byte sequence: invalid byte value range', () {
+          final bytes = [230, 256, 172];
+          final isValid = utf8Validator.validate(bytes);
+          expect(isValid, isFalse);
+        });
+
+        test('invalid byte sequence: more than 4 bytes', () {
+          final bytes = [230, 130, 172, 143, 143];
+          final isValid = utf8Validator.validate(bytes);
+          expect(isValid, isFalse);
+        });
+
+        test('invalid byte sequence: bad leading byte', () {
+          final bytes = [170, 130, 172];
+          final isValid = utf8Validator.validate(bytes);
+          expect(isValid, isFalse);
+        });
+
+        test('invalid byte sequence: bad continuation byte(s)', () {
+          final bytes = [230, 202, 138];
+          final isValid = utf8Validator.validate(bytes);
+          expect(isValid, isFalse);
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Changes

- Implement UTF-8 Validator class to validate characters encoded with a list of byte values
- Add dispatcher logic to handle multiple different forms of representation
- Add test suite for validator class

## Implementation Details
- `UTF8_Validator`: Wrapper class to store encoding parameters and handle validation logic. Supports:
    - Validation of one UTF-8 character encoded with a sequence of integer-valued bytes

## Testing
- Test coverage of core validation operations
- Edge cases: empty input, range errors, encoding errors